### PR TITLE
Add Gillian Black to Wall of Fame

### DIFF
--- a/frontend/data/contributors.json
+++ b/frontend/data/contributors.json
@@ -5,5 +5,12 @@
     "avatar": "https://github.com/lnovitz.png",
     "message": "Lianna was here! 🐱",
     "date": "2024-05-23"
+  }, 
+  {
+    "name": "Gillian Black",
+    "github": "gillian-black",
+    "avatar": "https://github.com/gillian-black.png",
+    "message": "Gillian was here! 🚀",
+    "date": "2025-07-29"
   }
 ] 


### PR DESCRIPTION
# Pull Request

## Description
Add Gillian Black to contributors wall of fame.

## Screenshots
Before:
<img width="1105" height="985" alt="Screenshot 2025-07-29 at 5 28 49 PM" src="https://github.com/user-attachments/assets/747b65e0-9277-4510-9725-3c2875c48a57" />
After:
<img width="1093" height="953" alt="Screenshot 2025-07-29 at 5 35 04 PM" src="https://github.com/user-attachments/assets/89c3476d-07fa-437f-9d67-f84d84ab7d6a" />

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license. 